### PR TITLE
Browser manager support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,10 +58,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           build-configuration: "${{ matrix.environment == 'Production' && 'Release' || 'Debug' }}"
           runtime-environment: "${{ matrix.environment }}"
-      - name: Test Reporter
-        uses: dorny/test-reporter@v1.9.1
-        with: 
-          artifact: ${{ matrix.browser }}-tests-Linux--Default            # artifact name
-          name: ${{ matrix.browser }} UI Tests                    # Name of the check run which will be created
-          path: '*.trx'                     # Path to test results (inside artifact .zip)
-          reporter: dotnet-trx              # Format of test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,3 +58,20 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           build-configuration: "${{ matrix.environment == 'Production' && 'Release' || 'Debug' }}"
           runtime-environment: "${{ matrix.environment }}"
+  report:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Test Reporter
+      uses: dorny/test-reporter@v1.9.1
+      with: 
+        artifact: chrome-tests-Linux--Default            # artifact name
+        name: Chrome UI Tests                    # Name of the check run which will be created
+        path: '*.trx'                     # Path to test results (inside artifact .zip)
+        reporter: dotnet-trx              # Format of test results
+    - name: Test Reporter
+      uses: dorny/test-reporter@v1.9.1
+      with: 
+        artifact: firefox-tests-Linux--Default            # artifact name
+        name: Firefox UI Tests                    # Name of the check run which will be created
+        path: '*.trx'                     # Path to test results (inside artifact .zip)
+        reporter: dotnet-trx              # Format of test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,20 +58,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           build-configuration: "${{ matrix.environment == 'Production' && 'Release' || 'Debug' }}"
           runtime-environment: "${{ matrix.environment }}"
-  report:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Test Reporter
-      uses: dorny/test-reporter@v1.9.1
-      with: 
-        artifact: chrome-tests-Linux--Default            # artifact name
-        name: Chrome UI Tests                    # Name of the check run which will be created
-        path: '*.trx'                     # Path to test results (inside artifact .zip)
-        reporter: dotnet-trx              # Format of test results
-    - name: Test Reporter
-      uses: dorny/test-reporter@v1.9.1
-      with: 
-        artifact: firefox-tests-Linux--Default            # artifact name
-        name: Firefox UI Tests                    # Name of the check run which will be created
-        path: '*.trx'                     # Path to test results (inside artifact .zip)
-        reporter: dotnet-trx              # Format of test results
+      - name: Test Reporter
+        uses: dorny/test-reporter@v1.9.1
+        with: 
+          artifact: ${{ matrix.browser }}-tests-Linux--Default            # artifact name
+          name: ${{ matrix.browser }} UI Tests                    # Name of the check run which will be created
+          path: '*.trx'                     # Path to test results (inside artifact .zip)
+          reporter: dotnet-trx              # Format of test results

--- a/src/Core/Riganti.Selenium.Core/Drivers/FastWebBrowserBase.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/FastWebBrowserBase.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using OpenQA.Selenium;
+using OpenQA.Selenium.Support.Extensions;
 using Riganti.Selenium.Core.Factories;
 
 namespace Riganti.Selenium.Core.Drivers
@@ -67,7 +68,31 @@ namespace Riganti.Selenium.Core.Drivers
         /// </summary>
         protected virtual void DeleteAllCookies()
         {
+
             driverInstance.Manage().Cookies.DeleteAllCookies();
+         
+            // Firefox driver doesn't list all cookies in Manage().Cookies - therefore JS invocation to remove all cookies
+            // Copied from https://stackoverflow.com/a/33366171
+            driverInstance.ExecuteJavaScript(
+                @"
+(function () {
+    var cookies = document.cookie.split(""; "");
+    for (var c = 0; c < cookies.length; c++) {
+        var d = window.location.hostname.split(""."");
+        while (d.length > 0) {
+            var cookieBase = encodeURIComponent(cookies[c].split("";"")[0].split(""="")[0]) + '=; expires=Thu, 01-Jan-1970 00:00:01 GMT; domain=' + d.join('.') + ' ;path=';
+            var p = location.pathname.split('/');
+            document.cookie = cookieBase + '/';
+            while (p.length > 0) {
+                document.cookie = cookieBase + p.join('/');
+                p.pop();
+            };
+            d.shift();
+        }
+    }
+})();
+"
+                );
         }
 
         /// <summary>

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/ChromeHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/ChromeHelpers.cs
@@ -16,7 +16,7 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             options.AddArgument("disable-popup-blocking");
 
             options.AddArguments(factory.Capabilities);
-            options.BrowserVersion = factory.Options.TryGetOrDefault(nameof(options.BrowserVersion), "stable");
+            options.BrowserVersion = factory.Options.TryGet(nameof(options.BrowserVersion));
 
             if (factory.GetBooleanOption("disableExtensions"))
             {

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/ChromeHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/ChromeHelpers.cs
@@ -1,19 +1,22 @@
-﻿using OpenQA.Selenium.Chrome;
+﻿using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
 using Riganti.Selenium.Core.Factories;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Riganti.Selenium.Core.Drivers.Implementation
 {
     public static class ChromeHelpers
     {
-
         public static ChromeDriver CreateChromeDriver(LocalWebBrowserFactory factory)
         {
-            
+
             var options = new ChromeOptions();
             options.AddArgument("test-type");
             options.AddArgument("disable-popup-blocking");
 
             options.AddArguments(factory.Capabilities);
+            options.BrowserVersion = factory.Options.TryGet(nameof(options.BrowserVersion));
 
             if (factory.GetBooleanOption("disableExtensions"))
             {
@@ -21,6 +24,5 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             }
             return new ChromeDriver(options);
         }
-
     }
 }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/ChromeHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/ChromeHelpers.cs
@@ -16,7 +16,7 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             options.AddArgument("disable-popup-blocking");
 
             options.AddArguments(factory.Capabilities);
-            options.BrowserVersion = factory.Options.TryGet(nameof(options.BrowserVersion));
+            options.BrowserVersion = factory.Options.TryGetOrDefault(nameof(options.BrowserVersion), "stable");
 
             if (factory.GetBooleanOption("disableExtensions"))
             {

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/CoordinatorWebBrowserBase.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/CoordinatorWebBrowserBase.cs
@@ -13,6 +13,5 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
         {
             Lease = lease;
         }
-        
     }
 }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/DictionaryExtensions.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/DictionaryExtensions.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace Riganti.Selenium.Core.Drivers.Implementation
+{
+    public static class DictionaryExtensions
+    {
+
+        public static T2 TryGet<T1, T2>(this IDictionary<T1,T2> dic, T1 key)
+        {
+            if(dic is not null && dic.TryGetValue(key, out T2 value) && value is T2)
+            {
+                return value;
+            }
+            return default;
+        }
+    }
+}

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/DictionaryExtensions.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/DictionaryExtensions.cs
@@ -5,13 +5,13 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
     public static class DictionaryExtensions
     {
 
-        public static T2 TryGetOrDefault<T1, T2>(this IDictionary<T1, T2> dic, T1 key, T2 defaultValue)
+        public static T2 TryGet<T1, T2>(this IDictionary<T1, T2> dic, T1 key)
         {
             if (dic is not null && dic.TryGetValue(key, out T2 value) && value is T2)
             {
                 return value;
             }
-            return defaultValue;
+            return default;
         }
     }
 }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/DictionaryExtensions.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/DictionaryExtensions.cs
@@ -5,13 +5,13 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
     public static class DictionaryExtensions
     {
 
-        public static T2 TryGet<T1, T2>(this IDictionary<T1,T2> dic, T1 key)
+        public static T2 TryGetOrDefault<T1, T2>(this IDictionary<T1, T2> dic, T1 key, T2 defaultValue)
         {
-            if(dic is not null && dic.TryGetValue(key, out T2 value) && value is T2)
+            if (dic is not null && dic.TryGetValue(key, out T2 value) && value is T2)
             {
                 return value;
             }
-            return default;
+            return defaultValue;
         }
     }
 }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/EdgeHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/EdgeHelpers.cs
@@ -11,7 +11,7 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             {
             };
 
-            options.BrowserVersion = factory.Options.TryGet(nameof(options.BrowserVersion));
+            options.BrowserVersion = factory.Options.TryGetOrDefault(nameof(options.BrowserVersion), "stable");
             return new EdgeDriver(options);
         }
     }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/EdgeHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/EdgeHelpers.cs
@@ -11,6 +11,7 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             {
             };
 
+            options.BrowserVersion = factory.Options.TryGet(nameof(options.BrowserVersion));
             return new EdgeDriver(options);
         }
     }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/EdgeHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/EdgeHelpers.cs
@@ -11,7 +11,7 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             {
             };
 
-            options.BrowserVersion = factory.Options.TryGetOrDefault(nameof(options.BrowserVersion), "stable");
+            options.BrowserVersion = factory.Options.TryGet(nameof(options.BrowserVersion));
             return new EdgeDriver(options);
         }
     }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/FirefoxHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/FirefoxHelpers.cs
@@ -7,68 +7,16 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
 {
     public static class FirefoxHelpers
     {
-        private static string pathToFirefoxBinary;
-        
         private static FirefoxDriverService service;
-        
+
         static FirefoxHelpers()
         {
             service = FirefoxDriverService.CreateDefaultService();
-            // service.LogLevel = FirefoxDriverLogLevel.Trace;
         }
 
         public static FirefoxDriver CreateFirefoxDriver(LocalWebBrowserFactory factory)
         {
-            factory.LogInfo($"Creating firefox driver from '{pathToFirefoxBinary}'.");
-
-            if (!string.IsNullOrWhiteSpace(pathToFirefoxBinary))
-            {
-                return CreateAlternativeInstance();
-            }
-
-            try
-            {
-                return new FirefoxDriver(service, GetFirefoxOptions());
-            }
-            catch (Exception e)
-            {
-                factory.LogInfo("Firefox driver could not be created.");
-                factory.LogError(e);
-
-                var env = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
-                if (env.Contains("(x86)"))
-                {
-                    env = env.Replace("(x86)", "").Trim();
-                }
-                var firefox = "Mozilla Firefox\\Firefox.exe";
-                if (File.Exists(Path.Combine(env, firefox)))
-                {
-                    return CreateAlternativeInstance(env, firefox);
-                }
-
-                env = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86);
-                if (File.Exists(Path.Combine(env, firefox)))
-                {
-                    return CreateAlternativeInstance(env, firefox);
-                }
-                throw;
-            }
-        }
-
-        private static FirefoxDriver CreateAlternativeInstance(string env, string firefox)
-        {
-            pathToFirefoxBinary = Path.Combine(env, firefox);
-            return CreateAlternativeInstance();
-        }
-
-        private static FirefoxDriver CreateAlternativeInstance()
-        {
-            var firefoxOptions = new FirefoxOptions()
-            {
-                BrowserExecutableLocation = pathToFirefoxBinary,
-                Profile = GetFirefoxProfile()
-            };
-            return new FirefoxDriver(firefoxOptions);
+            return new FirefoxDriver(service, GetFirefoxOptions(factory.Options));
         }
 
         public static FirefoxProfile GetFirefoxProfile()
@@ -80,9 +28,10 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             return profile;
         }
 
-        public static FirefoxOptions GetFirefoxOptions()
+        public static FirefoxOptions GetFirefoxOptions(System.Collections.Generic.IDictionary<string, string> _options)
         {
             var options = new FirefoxOptions { Profile = GetFirefoxProfile() };
+            options.BrowserVersion = _options.TryGet(nameof(options.BrowserVersion));
             return options;
         }
     }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/FirefoxHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/FirefoxHelpers.cs
@@ -31,7 +31,7 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
         public static FirefoxOptions GetFirefoxOptions(System.Collections.Generic.IDictionary<string, string> _options)
         {
             var options = new FirefoxOptions { Profile = GetFirefoxProfile() };
-            options.BrowserVersion = _options.TryGet(nameof(options.BrowserVersion));
+            options.BrowserVersion = _options.TryGetOrDefault(nameof(options.BrowserVersion), "stable");
             return options;
         }
     }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/FirefoxHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/FirefoxHelpers.cs
@@ -18,9 +18,7 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
 
         public static FirefoxDriver CreateFirefoxDriver(LocalWebBrowserFactory factory)
         {
-            Console.WriteLine("Firefox applies capabilities: " + JsonConvert.SerializeObject(factory.Capabilities));
             var ffOptions = GetFirefoxOptions(factory.Options);
-            Console.WriteLine("Firefox applies options: " + JsonConvert.SerializeObject(ffOptions));
             var driver = new FirefoxDriver(service, ffOptions);
             return driver;
         }
@@ -38,10 +36,9 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
         {
             var options = new FirefoxOptions
             {
-                //    Profile = GetFirefoxProfile()
+                Profile = GetFirefoxProfile()
             };
             options.BrowserVersion = _options.TryGet(nameof(options.BrowserVersion));
-            Console.WriteLine($"Requesting {options.BrowserVersion} version of browser");
             return options;
         }
     }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/FirefoxHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/FirefoxHelpers.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using Newtonsoft.Json;
 using OpenQA.Selenium.Firefox;
 using Riganti.Selenium.Core.Factories;
 
@@ -16,7 +18,11 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
 
         public static FirefoxDriver CreateFirefoxDriver(LocalWebBrowserFactory factory)
         {
-            return new FirefoxDriver(service, GetFirefoxOptions(factory.Options));
+            Console.WriteLine("Firefox applies capabilities: " + JsonConvert.SerializeObject(factory.Capabilities));
+            var ffOptions = GetFirefoxOptions(factory.Options);
+            Console.WriteLine("Firefox applies options: " + JsonConvert.SerializeObject(ffOptions));
+            var driver = new FirefoxDriver(service, ffOptions);
+            return driver;
         }
 
         public static FirefoxProfile GetFirefoxProfile()
@@ -30,8 +36,12 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
 
         public static FirefoxOptions GetFirefoxOptions(System.Collections.Generic.IDictionary<string, string> _options)
         {
-            var options = new FirefoxOptions { Profile = GetFirefoxProfile() };
-            options.BrowserVersion = _options.TryGetOrDefault(nameof(options.BrowserVersion), "stable");
+            var options = new FirefoxOptions
+            {
+                //    Profile = GetFirefoxProfile()
+            };
+            options.BrowserVersion = _options.TryGet(nameof(options.BrowserVersion));
+            Console.WriteLine($"Requesting {options.BrowserVersion} version of browser");
             return options;
         }
     }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/InternetExplorerHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/InternetExplorerHelpers.cs
@@ -12,7 +12,7 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             {
                 BrowserCommandLineArguments = "-private"
             };
-            options.BrowserVersion = factory.Options.TryGet(nameof(options.BrowserVersion));
+            options.BrowserVersion = factory.Options.TryGetOrDefault(nameof(options.BrowserVersion), "stable");
             return new InternetExplorerDriver(options);
         }
     }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/InternetExplorerHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/InternetExplorerHelpers.cs
@@ -12,7 +12,7 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             {
                 BrowserCommandLineArguments = "-private"
             };
-            options.BrowserVersion = factory.Options.TryGetOrDefault(nameof(options.BrowserVersion), "stable");
+            options.BrowserVersion = factory.Options.TryGet(nameof(options.BrowserVersion));
             return new InternetExplorerDriver(options);
         }
     }

--- a/src/Core/Riganti.Selenium.Core/Drivers/Implementation/InternetExplorerHelpers.cs
+++ b/src/Core/Riganti.Selenium.Core/Drivers/Implementation/InternetExplorerHelpers.cs
@@ -12,9 +12,8 @@ namespace Riganti.Selenium.Core.Drivers.Implementation
             {
                 BrowserCommandLineArguments = "-private"
             };
-
+            options.BrowserVersion = factory.Options.TryGet(nameof(options.BrowserVersion));
             return new InternetExplorerDriver(options);
         }
-
     }
 }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Authors>RIGANTI</Authors>
     <Description>Basic utilities for performing UI tests based on selenium on CI servers.</Description>
     <PackageTags>selenium;ui;tests;riganti;ci</PackageTags>
-    <Version>3.0.0-preview15-final</Version>
+    <Version>3.0.0-preview16-browser-manager</Version>
     <PackageIcon>Icon.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/riganti/selenium-utils</RepositoryUrl>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <Authors>RIGANTI</Authors>
     <Description>Basic utilities for performing UI tests based on selenium on CI servers.</Description>
     <PackageTags>selenium;ui;tests;riganti;ci</PackageTags>
-    <Version>3.0.0-preview16-browser-manager</Version>
+    <Version>3.0.0-preview17-browser-manager</Version>
     <PackageIcon>Icon.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/riganti/selenium-utils</RepositoryUrl>

--- a/src/Integrations/Riganti.Selenium.xUnit/XunitTestSuiteRunner.cs
+++ b/src/Integrations/Riganti.Selenium.xUnit/XunitTestSuiteRunner.cs
@@ -23,30 +23,4 @@ namespace Riganti.Selenium.xUnitIntegration
             base.RunInAllBrowsers(testClass, action, callerMemberName, callerFilePath, callerLineNumber);
         }
     }
-
-    //public class SeleniumInternalXunitRunnerReporter : Xunit.IRunnerReporter
-    //{
-    //    public string Description => "This reporter is a bit hack to close all resources when test execution ends.";
-
-    //    public bool IsEnvironmentallyEnabled => true;
-
-    //    public string RunnerSwitch => "riganti-selenium";
-
-    //    public IMessageSink CreateMessageHandler(IRunnerLogger logger)
-    //    {
-    //        return new SeleniumMessageSink();
-    //    }
-    //}
-    //public class SeleniumMessageSink : IMessageSink
-    //{
-    //    public bool OnMessage(IMessageSinkMessage message)
-    //    {
-    //        if (message is TestAssemblyExecutionFinished)
-    //        {
-    //            if (Debugger.IsAttached)
-    //                Debugger.Break();
-    //        }
-    //        return true;
-    //    }
-    //}
 }

--- a/src/Riganti.Selenium.DotVVM3Samples/Riganti.Selenium.DotVVM3.Samples.csproj
+++ b/src/Riganti.Selenium.DotVVM3Samples/Riganti.Selenium.DotVVM3.Samples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 	</PropertyGroup>
 	<ItemGroup>
 		<Content Include="**/*.dothtml;**/*.dotmaster;**/*.dotcontrol" Exclude="obj/**/*.*;bin/**/*.*" CopyToPublishDirectory="Always" />

--- a/src/Tests/Riganti.Selenium.Core.Samples.Assert.Tests/seleniumconfig.json
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Assert.Tests/seleniumconfig.json
@@ -1,7 +1,8 @@
 ﻿{
   "factories": {
     "chrome:fast": {
-      "capabilities": [ "--window-size=1920,1080" ]//, "--headless", "--disable-gpu" ]
+      "capabilities": [ "--window-size=1920,1080" , "--headless", "--disable-gpu" ], 
+      "BrowserVersion": "124"
     }
     //"firefox:dev": {
     //}

--- a/src/Tests/Riganti.Selenium.Core.Samples.Assert.Tests/seleniumconfig.json
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Assert.Tests/seleniumconfig.json
@@ -1,8 +1,10 @@
 ﻿{
   "factories": {
     "chrome:fast": {
-      "capabilities": [ "--window-size=1920,1080" , "--headless", "--disable-gpu" ], 
-      "BrowserVersion": "124"
+      "capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ],
+      "Options": {
+        "BrowserVersion": "124"
+      }
     }
     //"firefox:dev": {
     //}

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/BrowsersStabilityUiTests.cs
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/BrowsersStabilityUiTests.cs
@@ -70,15 +70,23 @@ namespace Riganti.Selenium.Core.Samples.FluentApi.Tests
         }
 
         [TestMethod]
-        [ExpectedSeleniumException(typeof(JavaScriptException))]
         public void SelectMethod_InvalidXPathSelector_ExpectedException()
         {
-            this.RunInAllBrowsers(browser =>
+            try
             {
-                browser.NavigateToUrl("/test/ClickTest");
-                var elem = browser.Single("#span");
-                elem.Single("///***-*///@@##@šš+š++++---><<>''", By.XPath);
-            });
+                this.RunInAllBrowsers(browser =>
+                {
+                    browser.NavigateToUrl("/test/ClickTest");
+                    var elem = browser.Single("#span");
+                    elem.Single("///***-*///@@##@šš+š++++---><<>''", By.XPath);
+                });
+                throw new System.Exception("SelectMethod_InvalidXPathSelector_ExpectedException was supposed to fail!!!");
+            }
+            catch (System.Exception)
+            {
+                // ignore
+                // reason: Firefox driver and Chrome driver throw different exceptions
+            }
         }
     }
 }

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/BrowsersStabilityUiTests.cs
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/BrowsersStabilityUiTests.cs
@@ -80,13 +80,14 @@ namespace Riganti.Selenium.Core.Samples.FluentApi.Tests
                     var elem = browser.Single("#span");
                     elem.Single("///***-*///@@##@šš+š++++---><<>''", By.XPath);
                 });
-                throw new System.Exception("SelectMethod_InvalidXPathSelector_ExpectedException was supposed to fail!!!");
             }
             catch (System.Exception)
             {
                 // ignore
                 // reason: Firefox driver and Chrome driver throw different exceptions
+                return;
             }
+            throw new System.Exception("SelectMethod_InvalidXPathSelector_ExpectedException was supposed to fail!!!");
         }
     }
 }

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/BrowsersStabilityUiTests.cs
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/BrowsersStabilityUiTests.cs
@@ -70,7 +70,7 @@ namespace Riganti.Selenium.Core.Samples.FluentApi.Tests
         }
 
         [TestMethod]
-        [ExpectedSeleniumException(typeof(InvalidSelectorException))]
+        [ExpectedSeleniumException(typeof(JavaScriptException))]
         public void SelectMethod_InvalidXPathSelector_ExpectedException()
         {
             this.RunInAllBrowsers(browser =>

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/FunctionsUiTests.cs
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/FunctionsUiTests.cs
@@ -253,7 +253,7 @@ namespace Riganti.Selenium.Core.Samples.FluentApi.Tests
                 browser.NavigateToUrl("/test/Cookies");
                 browser.First("#CookieIndicator").CheckIfInnerTextEquals("default value");
                 
-                browser.Click("#SetCookies").Wait();
+                browser.Click("#SetCookies").Wait(1000);
                 browser.NavigateToUrl("/test/Cookies");
                 browser.First("#CookieIndicator").CheckIfInnerTextEquals("new value");
             };

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/Profiles/seleniumconfig.chrome.json
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/Profiles/seleniumconfig.chrome.json
@@ -1,7 +1,10 @@
 {
     "factories": {
       "chrome:fast": {
-        "capabilities": [ "--no-sandbox" ]
+        "capabilities": [ "--no-sandbox" ],
+        "Options": {
+          "BrowserVersion": "124"
+        }
       }
     },
     "baseUrls": [

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/SeleniumManagerTests.cs
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/SeleniumManagerTests.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using OpenQA.Selenium;
+
+[TestClass]
+public class SeleniumManagerTests
+{
+    [TestMethod]
+    public void GetBinariesVersion113()
+    {
+        var data1 = SeleniumManager.BinaryPaths("--browser firefox --driver geckodriver --browser-version 113");
+        Console.WriteLine("Firefox binaries: " + JsonConvert.SerializeObject(data1));
+        Assert.IsNotNull(data1["browser_path"]);
+        Assert.IsNotNull(data1["driver_path"]);
+
+        var data2 = SeleniumManager.BinaryPaths("--browser chrome --driver chromedriver --browser-version 113");
+        Console.WriteLine("Chrome binaries: " + JsonConvert.SerializeObject(data2));
+        Assert.IsNotNull(data2["browser_path"]);
+        Assert.IsNotNull(data2["driver_path"]);
+    }
+
+    [TestMethod]
+    public void GetBinariesVersionStable()
+    {
+        var data1 = SeleniumManager.BinaryPaths("--browser firefox --driver geckodriver --browser-version stable");
+        Console.WriteLine("Firefox binaries: " + JsonConvert.SerializeObject(data1));
+        Assert.IsNotNull(data1["browser_path"]);
+        Assert.IsNotNull(data1["driver_path"]);
+
+        var data2 = SeleniumManager.BinaryPaths("--browser chrome --driver chromedriver --browser-version stable");
+        Console.WriteLine("Chrome binaries: " + JsonConvert.SerializeObject(data2));
+        Assert.IsNotNull(data2["browser_path"]);
+        Assert.IsNotNull(data2["driver_path"]);
+    }
+}

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/seleniumconfig.json
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/seleniumconfig.json
@@ -2,11 +2,14 @@
   "factories": {
     "chrome:fast": {
       "capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ],
-      "BrowserVersion": "124"
+      "Options": {
+        "BrowserVersion": "124"
+      }
     },
     //"firefox:fast": {
-    //  "capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ],
-    //  "BrowserVersion": "stable"
+    //  "Options": {
+    //    "BrowserVersion": "104"
+    //  }
     //}
     //"chrome:coordinator": {
     //  "options": {

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/seleniumconfig.json
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/seleniumconfig.json
@@ -1,7 +1,8 @@
 ﻿{
   "factories": {
     "chrome:fast": {
-      "capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ]
+      "capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ], 
+      "BrowserVersion": "124" 
     }
     //"chrome:coordinator": {
     //  "options": {

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/seleniumconfig.json
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/seleniumconfig.json
@@ -1,8 +1,12 @@
 ﻿{
   "factories": {
-    "chrome:fast": {
-      "capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ], 
-      "BrowserVersion": "124" 
+    //"chrome:fast": {
+    //  "capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ],
+    //  "BrowserVersion": "124"
+    //},
+    "firefox:fast": {
+      //"capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ],
+      "BrowserVersion": "stable"
     }
     //"chrome:coordinator": {
     //  "options": {

--- a/src/Tests/Riganti.Selenium.Core.Samples.Tests/seleniumconfig.json
+++ b/src/Tests/Riganti.Selenium.Core.Samples.Tests/seleniumconfig.json
@@ -1,13 +1,13 @@
 ﻿{
   "factories": {
-    //"chrome:fast": {
+    "chrome:fast": {
+      "capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ],
+      "BrowserVersion": "124"
+    },
+    //"firefox:fast": {
     //  "capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ],
-    //  "BrowserVersion": "124"
-    //},
-    "firefox:fast": {
-      //"capabilities": [ "--window-size=1920,1080", "--headless", "--disable-gpu" ],
-      "BrowserVersion": "stable"
-    }
+    //  "BrowserVersion": "stable"
+    //}
     //"chrome:coordinator": {
     //  "options": {
     //    "coordinatorUrl": "http://localhost:62242/"

--- a/src/Tests/Riganti.Selenium.Core.UnitTests/SeleniumManagerTests.cs
+++ b/src/Tests/Riganti.Selenium.Core.UnitTests/SeleniumManagerTests.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
+
+[TestClass]
+public class SeleniumManagerTests
+{
+    [TestMethod]
+    public void GetBinaries()
+    {
+        var data1 = SeleniumManager.BinaryPaths("--browser firefox --driver geckodriver --browser-version 104");
+        Console.WriteLine("Firefox binaries: " + JsonSerializer.Serialize(data1));
+        Assert.IsNotNull(data1["browser_path"]);
+        Assert.IsNotNull(data1["driver_path"]);
+
+        var data2 = SeleniumManager.BinaryPaths("--browser chrome --driver chromedriver --browser-version 104");
+        Console.WriteLine("Chrome binaries: " + JsonSerializer.Serialize(data2));
+        Assert.IsNotNull(data2["browser_path"]);
+        Assert.IsNotNull(data2["driver_path"]);
+    }
+}

--- a/src/Tests/Riganti.Selenium.Sandbox/seleniumconfig.json
+++ b/src/Tests/Riganti.Selenium.Sandbox/seleniumconfig.json
@@ -1,7 +1,9 @@
 ﻿{
   "factories": {
     "firefox:fast": {
-      "BrowserVersion": "stable"
+      "Options": {
+        "BrowserVersion": "stable"
+      }
     }
   },
   "baseUrls": [

--- a/src/Tests/Riganti.Selenium.Sandbox/seleniumconfig.json
+++ b/src/Tests/Riganti.Selenium.Sandbox/seleniumconfig.json
@@ -1,6 +1,8 @@
 ﻿{
   "factories": {
-    "firefox:fast": {}
+    "firefox:fast": {
+      "BrowserVersion": "stable"
+    }
   },
   "baseUrls": [
     "http://localhost:6278/"


### PR DESCRIPTION
Selenium.WebDriver is distributed with browser manager since version 4.11. Browser manager makes sure that driver and browser are compatible and therefore the tests are not failing due to incompatibility of underlaying testing platform. In addition, browser manager is able to download webdrivers and browsers binaries (CfT).